### PR TITLE
Add patch system to build script

### DIFF
--- a/custom/build.sh
+++ b/custom/build.sh
@@ -41,6 +41,12 @@ cd "${proj_dir}"
 # Contabo does not declare attributes as nullable, so I have to catch them manually
 sed -i 's/^\(\s\+\)self\.\([a-z][a-z_]\+\) = \2$/\1if \2 is not None:\n\1    self.\2 = \2/g' pfruck_contabo/models/*_response{,_data}.py
 
+# apply custom patches to source files
+for patchfile in $(find custom/patches -type f)
+do
+  patch -p0 < "${patchfile}"
+done
+
 # No functionality in unit-tests, they just validate that all files have valid syntax :)
 python -m unittest
 

--- a/custom/patches/rest.py.patch
+++ b/custom/patches/rest.py.patch
@@ -1,0 +1,21 @@
++++ pfruck_contabo/rest.py
+@@ -52,6 +52,7 @@
+ class RESTClientObject(object):
+
+     def __init__(self, configuration, pools_size=4, maxsize=None):
++        self.configuration = configuration
+         # urllib3.PoolManager will pass all kw parameters to connectionpool
+         # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/poolmanager.py#L75  # noqa: E501
+         # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/connectionpool.py#L680  # noqa: E501
+@@ -137,6 +138,11 @@
+         post_params = post_params or {}
+         headers = headers or {}
+
++        for auth_key in self.configuration.api_key:
++            prefix = self.configuration.api_key_prefix.get(auth_key)
++            auth_key_value = self.configuration.api_key[auth_key]
++            headers[auth_key] = f"{prefix} {auth_key_value}" if prefix else auth_key_value
++
+         timeout = None
+         if _request_timeout:
+             if isinstance(_request_timeout, (int, ) if six.PY3 else (int, long)):  # noqa: E501,F821


### PR DESCRIPTION
fixes #1

In the latest API spec change the Authentication section has been removed from the spec. This PR introduces an extensible patch system to the build script and provides a patch file for the missing authentication section.